### PR TITLE
(GH-3) Add Appveyor CI test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: 1.0.{build}
+
+image: WMF 5
+
+build: off
+
+# Uncomment this block to enable RDP access to the AppVeyor test instance for
+# debugging purposes.
+# on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+test_script:
+- ps: . .\build.ps1 -Task Test

--- a/build.ps1
+++ b/build.ps1
@@ -15,8 +15,17 @@ Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 if (-not (Get-Module -Name PSDepend -ListAvailable)) {
     Install-Module -Name PSDepend -Repository PSGallery -Confirm:$false -ErrorAction Stop
 }
+
+@('buildhelpers','psake','pester','psscriptanalyzer','poshbot') | % {
+  $moduleName = $_
+    if (-not (Get-Module -Name $moduleName -ListAvailable)) {
+        Install-Module -Name $moduleName -Repository PSGallery -Force -AllowClobber -Confirm:$false -ErrorAction Stop
+    }
+}
+
 Import-Module PSDepend -Verbose:$false -Force
-Invoke-PSDepend -Path $PSScriptRoot\requirements.psd1 -Install -Import -Force
+# PS Depend is causing issues in AppVeyor. Disabling for time being
+# Invoke-PSDepend -Path $PSScriptRoot\requirements.psd1 -Install -Import -Force
 
 if ($PSBoundParameters.ContainsKey('help')) {
     Get-PSakeScriptTasks -buildFile "$PSScriptRoot\psake.ps1" |

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -9,4 +9,5 @@
     psake            = 'latest'
     pester           = 'latest'
     psscriptanalyzer = 'latest'
+    poshbot          = 'latest'
 }


### PR DESCRIPTION
This commit updates build.ps1 for running automated unit tests within Appveyor.
This commit also disables the use of PSDepends as it was casuing issues with
AppVeyor not importing the PoshBot module due to function naming conflicts with
the Configuration module.  This commit also modidies the behavior of Pester to
output the test results when running in an AppVeyor build environment.